### PR TITLE
feat(editorconfig): configure `.editorconfig` with tabs and project rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,8 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = space
-indent_size = 2
+indent_style = tab
+indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,4 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.md]
-max_line_length = off
 trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 
 [*]
 charset = utf-8
+end_of_line = lf
 indent_style = tab
 indent_size = 4
 insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,8 +4,8 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_style = tab
 indent_size = 4
+indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,10 +9,6 @@ indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.ts]
-quote_type = single
-ij_typescript_use_double_quotes = false
-
 [*.md]
 max_line_length = off
 trim_trailing_whitespace = false


### PR DESCRIPTION
# feat(editorconfig): configure `.editorconfig` with tabs and project rules

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P1 | XS | 02-03-2026 | 02-03-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| <img width="586" height="445" alt="Image" src="https://github.com/user-attachments/assets/05eb7c30-ad4f-441a-827a-14b07192433b" /> | <img width="580" height="364" alt="Image" src="https://github.com/user-attachments/assets/c3accb0c-cf32-4567-84d7-96898a1aeafc" /> |

## 🔄 Type of Change

- [ ] Bug fix
- [ ] Breaking change
- [ ] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

- Configure `.editorconfig` to use tabs instead of spaces for indentation
- Set tab width to 4 characters and add `end_of_line` property
- Remove `TypeScript`-specific rules (handled by `Prettier`/`ESLint`)
- Update markdown section

## 📋 Changes Made

### Configuration
- Update `indent_style` and `indent_size` properties to use tabs with 4-character width
- Add `end_of_line = lf` property for consistent line endings
- Reorder properties in `[*]` section alphabetically
- Remove `[*.ts]` section (quote rules managed by `Prettier`/`ESLint`)
- Update `[*.md]` section (remove `max_line_length`, keep `trim_trailing_whitespace`)

## 🧪 Tests

- [x] Verify `.editorconfig` file is valid
- [x] Verify indentation works correctly in `VS Code`
- [x] Verify markdown files preserve trailing whitespace

## 🔗 References

### Related Issues
- Closes #3