### PR TITLE
feat(license): add `LICENSE` file with `MIT`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Beatriz Sopeña Merino
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+
+## License
+
+This project is licensed under the MIT License, which allows free use, modification and distribution. See [LICENSE](LICENSE) for details.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "angular-setup",
   "version": "0.0.0",
+  "license": "MIT",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
# feat(license): add `LICENSE` file with `MIT`

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P2 | XS | 02-03-2026 | 02-03-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | <img width="788" height="522" alt="Captura de pantalla 2026-03-02 a las 21 31 18" src="https://github.com/user-attachments/assets/be1b26aa-9dcc-4b56-8433-cd60fe4f68d2" /> |

## 🔄 Type of Change

- [ ] Bug fix
- [ ] Breaking change
- [ ] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [x] Documentation
- [ ] CI/CD

## 📝 Summary

- Add `MIT` license to the project
- Create `LICENSE` file, add `license` field to `package.json` and license section to `README.md`

## 📋 Changes Made

### Configuration
- Add `license` field with value `MIT` to `package.json`

### Documentation
- Create `LICENSE` file with `MIT` license text
- Add `## 📄 License` section to `README.md`

## 🧪 Tests

- [x] Verify `LICENSE` file exists and contains `MIT` license text
- [x] Verify `package.json` has `"license": "MIT"`
- [x] Verify `README.md` has `## 📄 License` section

## 🔗 References

### Related Issues
- Closes #9