### PR TITLE
feat(package): add `author` metadata as `JSON` object to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "angular-setup",
   "version": "0.0.0",
+  "author": {
+    "name": "Beatriz Sopeña Merino",
+    "email": "beatrizsmerino@gmail.com",
+    "url": "https://github.com/beatrizsmerino"
+  },
   "license": "MIT",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
# feat(package): add `author` metadata as `JSON` object to `package.json`

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P2 | XS | 02-03-2026 | 02-03-2026 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change

- [ ] Bug fix
- [ ] Breaking change
- [ ] Dependency
- [x] New feature
- [ ] Improvement
- [x] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

- Add `author` field to `package.json` as a structured JSON object with `name`, `email` and `url` properties

## 📋 Changes Made

### Configuration
- Add `author` field to `package.json` with `name`, `email` and `url` properties

## 🧪 Tests

- [x] Verify `package.json` is valid:

```bash
npm install
```

## 🔗 References

### Related Issues
- Closes #11

### Documentation
- https://docs.npmjs.com/cli/v10/configuring-npm/package-json#people-fields-author-contributors